### PR TITLE
Replace Twitter logo with X logo

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,10 +14,10 @@
 		{% endif %}
 
 		{% if site.twitter_username %}
-			<a href="https://twitter.com/{{ site.twitter_username }}">
+			<a href="https://x.com/{{ site.twitter_username }}">
 				<span class="fa-stack fa-1x">
 					<i class="socialIconBack fas fa-circle fa-stack-2x"></i>
-					<i class="socialIconTop fab fa-twitter fa-stack-1x"></i>
+					<i class="socialIconTop fab fa-x-twitter fa-stack-1x"></i>
 				</span>
 			</a>
 		{% endif %}


### PR DESCRIPTION
Update Twitter social media icon and link to X.com using FontAwesome's `fa-x-twitter`.