### PR TITLE
Add visible brand name to header and update styling; set `app_name` in config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ appstore_link                             : https://apps.apple.com/us/app/life-c
 presskit_download_link                    :
 
 app_icon                                  : assets/appicon.png
-app_name                                  :
+app_name                                  : Life Clock
 app_price                                 :
 app_description                           : Imagine your entire life, from birth to death, laid out on a 24-hour clock — what time would it be for you, right now?
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,7 +12,7 @@
 		{% else %}
 			<img class="headerIcon" src="{{ site.app_icon | relative_url }}">
 		{% endif %}
-		<p>{{ site.app_name }}</p>
+		<p class="headerName" aria-label="Life Clock brand name">Life Clock</p>
 	</div>
 	<nav>
 		<ul>

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -20,12 +20,15 @@ header {
 	gap: 12px;
 }
 
-.logo > p {
+.logo > p,
+.headerName {
 	color: $header-title-color;
 	white-space: nowrap;
-	font-weight: 600;
+	font-weight: 700;
 	font-size: 1.8rem;
-	letter-spacing: -0.01em;
+	letter-spacing: 0.02em;
+	text-transform: uppercase;
+	text-shadow: 0 1px 8px rgba($accent-color, 0.2);
 }
 
 .headerIcon {
@@ -65,7 +68,8 @@ nav > ul li a:active {
 		padding: 16px 20px;
 	}
 
-	.logo > p {
+	.logo > p,
+	.headerName {
 		display: none;
 	}
 


### PR DESCRIPTION
### Motivation
- Ensure the site shows a consistent, accessible brand name in the header and provide the application name in the site config for templates and metadata.

### Description
- Set `app_name` to `Life Clock` in `_config.yml` and replace the dynamic `{{ site.app_name }}` output with a static, accessible `<p class="headerName" aria-label="Life Clock brand name">Life Clock</p>` in `_includes/header.html`.
- Update `_sass/layout.scss` to include `.headerName` alongside the existing logo paragraph styles, increase font weight and spacing, add uppercase transformation and a subtle text shadow, and ensure the header name is hidden on small screens.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15b236790c8331834ef482a6cef2ce)